### PR TITLE
Introduce GcovFind command and more detailed highlighting specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ let g:gcov_marker_uncovered  = 'X'
 
 
 The *GcovFind* command needs to know where to look for the .gcov files.
-There is only one folder allowed, all the .gcov files has to be placed there.
+The variable takes a comma seperated list of folders.
 ```vimrc
 let g:gcov_marker_path  = 'path/to/gcov/files/'
 ```

--- a/README.md
+++ b/README.md
@@ -19,12 +19,22 @@ you do not get detailed information like the number of hits or branches.
 In the window of your source file, run command
 :GcovLoad source.gcov
 
+If *g:gcov_marker_path* contains a folder with all your .gcov files, run
+:GcovFind
+
 ## Configuration
 
 Default markers can be customized using the variables below.
 ```vimrc
 let g:gcov_marker_covered    = '✓'
 let g:gcov_marker_uncovered  = 'X'
+```
+
+
+The *GcovFind* command needs to know where to look for the .gcov files.
+There is only one folder allowed, all the .gcov files has to be placed there.
+```vimrc
+let g:gcov_marker_path  = 'path/to/gcov/files/'
 ```
 
 By default, the plugin opens the location list once uncovered lines are

--- a/autoload/gcov_marker.vim
+++ b/autoload/gcov_marker.vim
@@ -34,8 +34,8 @@ function gcov_marker#SetCov(...)
     call setloclist(0, [])
     let currentfile = expand('%')
     "Read coverage file (work only without branch coverage at the moment )
-    exe ":sign define gcov_covered linehl=GcovCovered text=" . g:gcov_marker_covered
-    exe ":sign define gcov_uncovered linehl=GcovUncovered text=" . g:gcov_marker_uncovered
+    exe ":sign define gcov_covered linehl=GcovCoveredLine texthl=GcovCoveredText text=" . g:gcov_marker_covered
+    exe ":sign define gcov_uncovered linehl=GcovUncoveredLine texthl=GcovUncoveredText text=" . g:gcov_marker_uncovered
     for line in readfile(filename)
         if line =~ ':'
             let d = split(line, ':')

--- a/autoload/gcov_marker.vim
+++ b/autoload/gcov_marker.vim
@@ -23,9 +23,13 @@ function gcov_marker#FindCov(...)
         endif
     endif
     let filename = expand('%:t')
-    let dirname = g:gcov_marker_path
-    echo "load file " . dirname . '/' . filename . ".gcov for coverage"
-    call gcov_marker#SetCov('<bang>', dirname . '/' . filename . ".gcov")
+    let files = split(globpath(g:gcov_marker_path, filename . ".gcov"), '\n')
+    if (len(files) == 0)
+      echoerr "could not find any file named " . filename . ".gcov"
+      return
+    endif
+    echo "load file " . files[0] . " for coverage"
+    call gcov_marker#SetCov('<bang>', files[0])
   endfunction
 
 function gcov_marker#SetCov(...)

--- a/autoload/gcov_marker.vim
+++ b/autoload/gcov_marker.vim
@@ -10,7 +10,23 @@ else
     if !exists("g:gcov_marker_auto_lopen")
         let g:gcov_marker_auto_lopen = 1
     endif
+    if !exists("g:gcov_marker_path")
+        let g:gcov_marker_path = '.'
+    endif
 endif
+
+function gcov_marker#FindCov(...)
+    if (a:0 == 1)
+        if(a:1 == '!')
+            exe ":sign unplace *"
+            return
+        endif
+    endif
+    let filename = expand('%:t')
+    let dirname = g:gcov_marker_path
+    echo "load file " . dirname . '/' . filename . ".gcov for coverage"
+    call gcov_marker#SetCov('<bang>', dirname . '/' . filename . ".gcov")
+  endfunction
 
 function gcov_marker#SetCov(...)
     if(a:0 == 2)

--- a/autoload/gcov_marker.vim
+++ b/autoload/gcov_marker.vim
@@ -25,11 +25,24 @@ function gcov_marker#FindCov(...)
     let filename = expand('%:t')
     let files = split(globpath(g:gcov_marker_path, filename . ".gcov"), '\n')
     if (len(files) == 0)
-      echoerr "could not find any file named " . filename . ".gcov"
-      return
+        echoerr "could not find any file named " . filename . ".gcov"
+        return
     endif
-    echo "load file " . files[0] . " for coverage"
-    call gcov_marker#SetCov('<bang>', files[0])
+    " check current file name matches Source
+    for file in files
+        for line in readfile(file)
+            if line =~ ':.*:.*:'
+                let d = split(line, ':')
+                let c = substitute(d[0], " *", "", "")
+                let l = substitute(d[1], " *", "", "")
+                if c == '-' && l == 0 && d[2] =~ "Source" && d[3] == expand('%:p')
+                    echo "load file " . file . " for coverage"
+                    call gcov_marker#SetCov('<bang>', file)
+                    return
+                endif
+            endif
+        endfor
+    endfor
   endfunction
 
 function gcov_marker#SetCov(...)

--- a/doc/gcov_marker.txt
+++ b/doc/gcov_marker.txt
@@ -32,6 +32,12 @@ If no argument is given, the last file used for the buffer is used.
 
 If it is called with a bang the markers will be deleted.
 
+The *GcovFind* command
+
+This command uses the value of g:gcov_marker_path to find the ".gcov" file for the current buffer.
+
+If it is called with a bang the markers will be deleted.
+
 ------------------------------------------------------------------------------
                                                 *gcov-marker-configuration*
 Configuration ~
@@ -40,6 +46,11 @@ Default markers can be customized using the variables below.
 
 let g:gcov_marker_covered    = '✓'
 let g:gcov_marker_uncovered  = 'X'
+
+The *GcovFind* command needs to know where to look for the ".gcov" files.
+There is only one folder allowed, all the ".gcov" files has to be placed there.
+
+let g:gcov_marker_path  = 'path/to/gcov/files/'
 
 By default, the plugin opens the location list once uncovered lines are
 published. This behavior can be changed by setting the global variable below.

--- a/doc/gcov_marker.txt
+++ b/doc/gcov_marker.txt
@@ -47,8 +47,8 @@ Default markers can be customized using the variables below.
 let g:gcov_marker_covered    = '✓'
 let g:gcov_marker_uncovered  = 'X'
 
-The *GcovFind* command needs to know where to look for the ".gcov" files.
-There is only one folder allowed, all the ".gcov" files has to be placed there.
+The *GcovFind* command needs to know where to look for the ".gcov" files. The
+variable takes a comma seperated list of folders.
 
 let g:gcov_marker_path  = 'path/to/gcov/files/'
 

--- a/plugin/gcov_marker.vim
+++ b/plugin/gcov_marker.vim
@@ -3,5 +3,6 @@ if exists('g:loaded_gcov_marker') || &cp || version < 700
 endif
 
 command! -bang -nargs=* -complete=file GcovLoad call gcov_marker#SetCov('<bang>',<f-args>)
+command! -bang -nargs=0 GcovFind call gcov_marker#FindCov('<bang>')
 
 let g:loaded_gcov_marker = 1

--- a/syntax/gcov_marker.vim
+++ b/syntax/gcov_marker.vim
@@ -1,2 +1,4 @@
-highlight! GcovUncovered term=reverse cterm=reverse ctermfg=1 guifg=White guibg=Red
-highlight! GcovCovered   term=reverse cterm=reverse ctermfg=2 guifg=White guibg=Red
+highlight! GcovUncoveredLine term=reverse cterm=reverse ctermfg=1 guifg=White guibg=Red
+highlight! GcovCoveredLine   term=reverse cterm=reverse ctermfg=2 guifg=White guibg=Red
+highlight! GcovUncoveredText term=reverse cterm=bold ctermfg=red guifg=White guibg=Red
+highlight! GcovCoveredText   term=reverse cterm=bold ctermfg=green guifg=White guibg=Green


### PR DESCRIPTION
The GcovFind command is able to open a corresponding gcov file to the current buffer without any argument. It looks for the gcov file in a given list of directories.

The highlighting configuration allows now to define different highlighting styles for the sign and the corresponding line.